### PR TITLE
Flutter 2.5 KeyboardListener fix

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:keyboard_utils/keyboard_utils.dart';
-import 'package:keyboard_utils/keyboard_listener.dart';
+import 'package:keyboard_utils/keyboard_listener.dart' as keyboard_listener;
 import 'package:keyboard_utils/widgets.dart';
 
 void main() => runApp(MyApp());
@@ -20,7 +20,7 @@ class KeyboardBloc {
 
   void start() {
     _idKeyboardListener = _keyboardUtils.add(
-        listener: KeyboardListener(willHideKeyboard: () {
+        listener: keyboard_listener.KeyboardListener(willHideKeyboard: () {
       _streamController.sink.add(_keyboardUtils.keyboardHeight);
     }, willShowKeyboard: (double keyboardHeight) {
       _streamController.sink.add(keyboardHeight);

--- a/lib/keyboard_aware/keyboard_aware.dart
+++ b/lib/keyboard_aware/keyboard_aware.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide KeyboardListener;
 import 'package:keyboard_utils/keyboard_listener.dart';
 import 'package:keyboard_utils/keyboard_options.dart';
 import 'package:keyboard_utils/keyboard_utils.dart';


### PR DESCRIPTION
material.dart includes now a KeyboardListener in flutter 2.5, so we just hide it to make it work again.